### PR TITLE
Move editor to bottom panel and increase default vertical size

### DIFF
--- a/addons/json_editor/json_dock.tscn
+++ b/addons/json_editor/json_dock.tscn
@@ -19,6 +19,7 @@ image = SubResource( 3 )
 size = Vector2( 16, 16 )
 
 [node name="JSON" type="PanelContainer"]
+rect_min_size = Vector2( 0, 192 )
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -28,7 +29,7 @@ __meta__ = {
 margin_left = 7.0
 margin_top = 7.0
 margin_right = 143.0
-margin_bottom = 42.0
+margin_bottom = 185.0
 dragger_visibility = 1
 __meta__ = {
 "_edit_use_anchors_": false
@@ -66,10 +67,12 @@ tooltip = "Load a JSON file from disk"
 margin_left = 64.0
 margin_right = 92.0
 margin_bottom = 22.0
+hint_tooltip = "Save contents to disk"
 icon = SubResource( 2 )
 flat = true
 script = ExtResource( 2 )
 icon_name = "Save"
+type = "EditorIcons"
 tooltip = "Save contents to disk"
 
 [node name="File Name" type="Label" parent="VSplitContainer/Tools/Left"]
@@ -96,7 +99,7 @@ tooltip = "Close files and discard any changes"
 [node name="Tree" type="Tree" parent="VSplitContainer"]
 margin_top = 34.0
 margin_right = 136.0
-margin_bottom = 35.0
+margin_bottom = 178.0
 columns = 3
 __meta__ = {
 "_edit_use_anchors_": false

--- a/addons/json_editor/plugin.gd
+++ b/addons/json_editor/plugin.gd
@@ -22,10 +22,10 @@ func _enter_tree() -> void:
 	dock.select_file_dialog = select_file_dialog
 	dock.confirmation_dialog = confirmation_dialog
 	dock.error_dialog = error_dialog
-	add_control_to_dock(DOCK_SLOT_RIGHT_UL, dock)
+	add_control_to_bottom_panel(dock, "JSON")
 
 func _exit_tree() -> void:
-	remove_control_from_docks(dock)
+	remove_control_from_bottom_panel(dock)
 	dock.free()
 	select_file_dialog.free()
 	confirmation_dialog.free()


### PR DESCRIPTION
It might be more convenient to have JSON editor in the bottom panel.
Preview:
![smqTld7aTg](https://user-images.githubusercontent.com/43543909/85202418-fcc67500-b30e-11ea-9129-b587bfa64dcc.png)
